### PR TITLE
Minor correctness fixes

### DIFF
--- a/galagino/galagino.ino
+++ b/galagino/galagino.ino
@@ -793,8 +793,8 @@ void setup() {
   Serial.println("I2S APLL workaround active"); 
 #endif
 
-  // this should not be needed as the CPU runs by default on 240Mht nowadays
-  setCpuFrequencyMhz(240000000);
+  // this should not be needed as the CPU runs by default on 240Mhz nowadays
+  setCpuFrequencyMhz(240);
 
   Serial.print("Free heap: "); Serial.println(ESP.getFreeHeap());
   Serial.print("Main core: "); Serial.println(xPortGetCoreID());

--- a/galagino/leds.h
+++ b/galagino/leds.h
@@ -24,7 +24,14 @@ extern void leds_update(void);
 extern void leds_check_galaga_sprite(struct sprite_S *spr);
 extern void leds_state_reset();
   
-#endif // LED_PIN 
+#else
+
+static inline void leds_init(void) {}
+static inline void leds_update(void) {}
+static inline void leds_check_galaga_sprite(struct sprite_S *spr) {}
+static inline void leds_state_reset(void) {}
+
+#endif // LED_PIN
 
 struct sprite_S {
   unsigned char code, color, flags;

--- a/galagino/pacman.h
+++ b/galagino/pacman.h
@@ -62,7 +62,7 @@ static inline void pacman_WrZ80(unsigned short Addr, unsigned char Value) {
       irq_enable[0] = Value & 1;
     
     if((Addr & 0xffe0) == 0x5040) {
-      if(soundregs[Addr - 0x5040] != Value & 0x0f)
+      if(soundregs[Addr - 0x5040] != (Value & 0x0f))
 	soundregs[Addr - 0x5040] = Value & 0x0f;
     }
     


### PR DESCRIPTION
setCpuFrequencyMhz takes MHz, not Hz — 240000000 is rejected by the ESP32 core as an invalid frequency and silently does nothing. Passes 240 so the call actually works (the CPU is already at 240MHz on boot, so no behavioral change).

Pac-Man sound register write had a precedence bug: "a != b & 0x0f" parses as "(a != b) & 0x0f" because != binds tighter than bitwise &. Added parentheses to compare against the masked value as intended. Functionally harmless since the write value is correct either way, just triggers occasional redundant writes.

Added no-op stubs in leds.h for builds without LED_PIN. galaga.h calls leds_state_reset() and leds_check_galaga_sprite() unconditionally, so without stubs these become link errors whenever LED_PIN is disabled.